### PR TITLE
feat(parse): add custom extractors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,75 @@
 # Actions Issue Parser
 
-Helps enable Service Desk style functionality in GitHub issues.
+Extract useful information from new issues for use in your GitHub Actions.
+
+## Getting Started
+
+Simply add this action to any workflow that runs on GitHub Issue `created` events and it will extract `key: value` pairs as `outputs` to be used in subsequent actions.
+
+#### Example Workflow
+```Yaml
+- id: parser
+  uses: jasonmacgowan/actions-parse-issue@v1
+- uses: actions/some-action@v1
+  with:
+    foo: ${{steps.parser.outputs.foo}}
+    bar: ${{steps.parser.outouts.bar}}
+```
+
+#### Example Issue
+
+```Yaml
+# Welcome
+
+foo: fizz
+bar: buzz
+```
+
+Given the workflow and issue above, this action will parse `foo` and `bar` with their values and make them available at `steps.parser.outputs`. In this example, the following would be defined:
+
+- `steps.parser.outputs.foo` (with a value of `fizz`)
+- `steps.parser.outputs.bar` (with a value of `buzz`)
+
+The `id` used is arbitrary, only used to reference the output in another step.
+
+### Default Extractor
+
+By default, this Action will extract all `key: value` pairs that it finds.  Duplicate keys will be overridden by the last value found.
+
+### Custom Extractors
+
+You can define custom extractors with regular expressions by defining inputs to this action in a specific prefix.  All inputs that start with `extract_` will be enumerated and made available on `outputs` based on the value passed in.  If you use a capture group, we will assign the first match and ignore the rest
+
+
+#### Examples
+
+<table>
+  <thead>
+    <tr>
+      <th>Workflow</th>
+      <th>Issue</th>
+      <th>Result</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><pre>uses: jasonmacgowan/actions-parse-issue@v1
+inputs:
+  extract_username: '&lt;p id="username">(?&lt;username>[^&lt;]+)&lt;/p>'
+  extract_email: '&lt;p id="email">johnsmith@example.com&lt;/p>'</pre></td>
+      <td><pre># Example Issue
+&lt;p id="username">johnsmith&lt;/p>
+&lt;p id="username">(?&lt;email>[^<]+)&lt;/p></pre></td>
+      <td><pre>username: johnsmith
+email: johnsmith@example.com</pre></td>
+    </tr>
+    <tr>
+      <td><pre>uses: jasonmacgowan/actions-parse-issue@v1
+inputs:
+  extract_awesome: '^(.+) is awesome!$'</pre></td>
+      <td><pre># Example Issue
+Everything is awesome!</pre></td>
+      <td><pre>awesome: Everything</pre></td>
+    </tr>
+  </tbody>
+</table>

--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -28,6 +28,20 @@ describe('parser', () => {
     ])
     expect(parse(body)).toEqual(params)
   })
+
+  test('parses out input extractions', () => {
+    process.env.INPUT_EXTRACT_SEASON = '<p id="season">(?<season>[^<]+)</p>'
+
+    const body = 'name: Mona\nsnack: cookies\ncolor: green\n<p id="season">winter</p>'
+    const params = new Map<string, string>([
+      ['name', 'Mona'],
+      ['snack', 'cookies'],
+      ['color', 'green'],
+      ['season', 'winter']
+    ])
+
+    expect(parse(body)).toEqual(params)
+  })
 })
 
 describe('default regex', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,41 @@
+/* globals describe expect test */
+
+import {getExtractions, getFirstMatch} from '../src/utils'
+
+describe('utils#getExtractions', () => {
+  test('parses environment variables', () => {
+    process.env.INPUT_EXTRACT_USERNAME = '<p id="username">(?<username>[^<]+)</p>'
+    process.env.INPUT_EXTRACT_USERNAME_FLAGS = 'gm'
+    process.env.INPUT_EXTRACT_EMAIL = '<p id="email">(?<email>[^<]+)</p>'
+
+    const expected = new Map<string, RegExp>([
+      ['username', new RegExp(process.env.INPUT_EXTRACT_USERNAME, process.env.INPUT_EXTRACT_USERNAME_FLAGS)],
+      ['email', new RegExp(process.env.INPUT_EXTRACT_EMAIL)]
+    ])
+
+    expect(getExtractions()).toEqual(expected)
+  })
+})
+
+describe('utils#getFirstMatch', () => {
+  test('gets a match', () => {
+    const regex = /mona/
+    const str = 'mona'
+
+    expect(getFirstMatch(regex, str)).toBe('mona')
+  })
+
+  test('gets a match with capture groups', () => {
+    const regex = /name: (mona)/
+    const str = 'name: mona'
+
+    expect(getFirstMatch(regex, str)).toBe('mona')
+  })
+
+  test('returns the first capture group when their are multiple', () => {
+    const regex = /(name): (mona)/
+    const str = 'name: mona'
+
+    expect(getFirstMatch(regex, str)).toBe('name')
+  })
+})

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,21 @@
+import {getExtractions, getFirstMatch} from './utils'
+
 const regex = /^(?<key>[^:\s][^:\r\n]*)\s*:\s*(?<value>[^\r\n]+)$/gm
+
+export function parseExtractions(body: string): Map<string, string> {
+  const params = new Map<string, string>()
+  const extractions = getExtractions()
+
+  for (const [key, matcher] of extractions.entries()) {
+    const value = getFirstMatch(matcher, body)
+
+    if (value) {
+      params.set(key, value)
+    }
+  }
+
+  return params
+}
 
 export function parse(body: string): Map<string, string> {
   const params: Map<string, string> = new Map()
@@ -14,5 +31,12 @@ export function parse(body: string): Map<string, string> {
     }
   } while (match !== null)
 
-  return params
+  const extractions = parseExtractions(body)
+
+  return new Map(
+    (function*() {
+      yield* params
+      yield* extractions
+    })()
+  )
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,38 @@
+export function getFirstMatch(regex: RegExp, str: string): string | null {
+  const match = regex.exec(str)
+
+  process.stdout.write(JSON.stringify(match))
+
+  if (match) {
+    let index = 0
+
+    if (match.length > 1) {
+      index = 1
+    }
+
+    return match[index]
+  }
+
+  return null
+}
+
+export function getExtractions(): Map<string, RegExp> {
+  const out = new Map<string, RegExp>()
+  const keys = Object.keys(process.env)
+
+  let i
+  for (i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    const value = process.env[key]
+
+    // INPUT_EXTRACT_USERNAME but not INPUT_EXTRACT_USERNAME_FLAGS
+    if (key.startsWith('INPUT_EXTRACT_') && !key.endsWith('_FLAGS')) {
+      if (value) {
+        const flags = process.env[`${key}_FLAGS`] || ''
+        out.set(key.replace('INPUT_EXTRACT_', '').toLowerCase(), new RegExp(value, flags))
+      }
+    }
+  }
+
+  return out
+}


### PR DESCRIPTION
Allow custom regular expressions alongside the default `key: value` parser