### PR TITLE
feat(parse): better defaults

### DIFF
--- a/__tests__/fixtures/issues/non-spaces-tabs.md
+++ b/__tests__/fixtures/issues/non-spaces-tabs.md
@@ -1,0 +1,2 @@
+name: Mona
+favorite color: blue

--- a/__tests__/fixtures/issues/non-word.md
+++ b/__tests__/fixtures/issues/non-word.md
@@ -1,0 +1,2 @@
+name: Mona
+<p>color: blue</p>

--- a/__tests__/fixtures/issues/spaces-tabs.md
+++ b/__tests__/fixtures/issues/spaces-tabs.md
@@ -1,0 +1,2 @@
+name: Mona
+color: royal blue

--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -31,9 +31,39 @@ describe('parser', () => {
 })
 
 describe('default regex', () => {
-  test('does not extract lines with leading whitespace', () => {
+  test('trims leading whitespace', () => {
     const body = loadFixture('issues/leading-whitespace.md')
-    const params = new Map<string, string>([['name', 'Mona']])
+    const params = new Map<string, string>([
+      ['name', 'Mona'],
+      ['color', 'blue']
+    ])
+    expect(parse(body)).toEqual(params)
+  })
+
+  test('does not match non-word characters', () => {
+    const body = loadFixture('issues/non-word.md')
+    const params = new Map<string, string>([
+      ['name', 'Mona'],
+      ['color', 'blue']
+    ])
+    expect(parse(body)).toEqual(params)
+  })
+
+  test('matches spaces and tabs as value', () => {
+    const body = loadFixture('issues/spaces-tabs.md')
+    const params = new Map<string, string>([
+      ['name', 'Mona'],
+      ['color', 'royal blue']
+    ])
+    expect(parse(body)).toEqual(params)
+  })
+
+  test('does not match spaces and tabs in key', () => {
+    const body = loadFixture('issues/spaces-tabs.md')
+    const params = new Map<string, string>([
+      ['name', 'Mona'],
+      ['color', 'royal blue']
+    ])
     expect(parse(body)).toEqual(params)
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -3090,7 +3090,7 @@ module.exports = opts => {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const regex = /^(?<key>[^:\s][^:\r\n]*)\s*:\s*(?<value>[^\r\n]+)$/gm;
+const regex = /\s*(?<key>[\w]+)\s*:\s*(?<value>[\w\t ]+)\s*/gm;
 function parse(body) {
     const params = new Map();
     let match;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,4 @@
-const regex = /^(?<key>[^:\s][^:\r\n]*)\s*:\s*(?<value>[^\r\n]+)$/gm
+const regex = /\s*(?<key>[\w]+)\s*:\s*(?<value>[\w\t ]+)\s*/gm
 
 export function parse(body: string): Map<string, string> {
   const params: Map<string, string> = new Map()


### PR DESCRIPTION
fixes #5

Don't match special characters in key/value pairs
Don't match whitespace in key
Match whitespace in value